### PR TITLE
chore: fix pip install syntax in readme

### DIFF
--- a/docs/validator.md
+++ b/docs/validator.md
@@ -7,5 +7,5 @@
 ## Steps
 1. Clone this repo
 2. Setup a venv with the path being .venv (make sure to activate as well) 
-3. Install validator requirements (ie `uv pip install requirements.validator.txt`)
+3. Install validator requirements (ie `uv pip install -r requirements.validator.txt`)
 4. Run auto update script via `python scripts/start_validator.py`


### PR DESCRIPTION
Amends the `uv pip install` syntax for installing from the requirements file, adding `-r`
```
(11) root@ubuntu-4gb-hel1-1:~/dippy-studio-bittensor# uv pip install requirements.validator.txt
✔ `requirements.validator.txt` looks like a local requirements file but was passed as a package name. Did you mean `-r requirements.validator.txt`? · yes
```